### PR TITLE
Use CMake FetchContent to include JUCE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "JUCE"]
-	path = JUCE
-	url = https://github.com/juce-framework/JUCE/
-	branch = develop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,17 @@ set(PREDEFINED_TARGETS_FOLDER "Targets")
 # Create a /Modules directory with all the JUCE Module code
 option(JUCE_ENABLE_MODULE_SOURCE_GROUPS "Show all module sources in IDE projects" ON)
 
-# JUCE is a submodule
-# Locally, you need to run `git submodule update --init --recursive` once
-# On Github Actions, it's managed by actions/checkout
-add_subdirectory(JUCE)
+# Include JUCE using CMake FetchContent
+include(FetchContent)
+FetchContent_Declare(
+        JUCE
+        GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+        GIT_TAG 3f78998b967979da8523030ba76e807d4431efcd
+	GIT_SHALLOW true
+	GIT_PROGRESS true
+
+)
+FetchContent_MakeAvailable(JUCE)
 
 # Check the readme at `docs/CMake API.md` in the JUCE repo for full config
 juce_add_plugin(Pamplejuce

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is a template for creating JUCE plugins with 2020 best practices
 Out of the box, it supports:
 
 1. C++20
-2. JUCE 6.x as a submodule, tracking develop
+2. JUCE 6.x include with CMake [FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html), tracking develop
 3. CMake 3.18
 4. Catch2 2.13.2
 5. Github Actions for both CI and artifact building
@@ -23,13 +23,7 @@ Out of the box, it supports:
 
 3. Replace `Pamplejuce` with the name of your project.
 
-4. 
-
-```
-git submodule update --init
-```
-
-5. Set the correct flags for your plugin under `juce_add_plugin`. Check out the API https://github.com/juce-framework/JUCE/blob/master/docs/CMake%20API.md
+4. Set the correct flags for your plugin under `juce_add_plugin`. Check out the API https://github.com/juce-framework/JUCE/blob/master/docs/CMake%20API.md
 
 
 ## How to build your project on MacOS

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is a template for creating JUCE plugins with 2020 best practices
 Out of the box, it supports:
 
 1. C++20
-2. JUCE 6.x include with CMake [FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html), tracking develop
+2. JUCE 6.x included with CMake [FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html), tracking `develop`
 3. CMake 3.18
 4. Catch2 2.13.2
 5. Github Actions for both CI and artifact building


### PR DESCRIPTION
This `FetchContent` call points to the current tip of the JUCE `develop` branch: `3f78998b967979da8523030ba76e807d4431efcd`.