### PR TITLE
Spruce up windows installer

### DIFF
--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -1,14 +1,30 @@
 #define Version Trim(FileRead(FileOpen("..\VERSION")))
+#define PluginName "Pamplejuce"
+#define Publisher "Melatonin"
 #define Year GetDateTimeString("yyyy","","")
 
 [Setup]
-AppName=Pamplejuce
-OutputBaseFilename=Pamplejuce-{#Version}-Windows
-AppCopyright=Copyright (C) {#Year} Melatonin
-AppPublisher=Melatonin
+ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64
+AppName={#PluginName}
+OutputBaseFilename={#PluginName}-{#Version}-Windows
+AppCopyright=Copyright (C) {#Year} {#Publisher}
+AppPublisher={#Publisher}
 AppVersion={#Version}
-DefaultDirName="{commoncf64}\VST3"
-DisableStartupPrompt=yes
+DefaultDirName="{commoncf64}\VST3\{#PluginName}.vst3"
+DisableDirPage=yes
+LicenseFile="..\LICENSE"
+UninstallFilesDir="{commonappdata}\{#PluginName}\uninstall"
 
+[UninstallDelete]
+Type: filesandordirs; Name: "{commoncf64}\VST3\{#PluginName}Data"
+
+; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
-Source: "{src}..\Builds\Pamplejuce_artefacts\Release\VST3\Pamplejuce.vst3\*.*"; DestDir: "{commoncf64}\VST3\Pamplejuce.vst3\"; Check: Is64BitInstallMode; Flags: external overwritereadonly ignoreversion; Attribs: hidden system;
+Source: "..\Builds\Pamplejuce_artefacts\Release\VST3\{#PluginName}.vst3\*"; DestDir: "{commoncf64}\VST3\{#PluginName}.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs;
+
+[Run]
+Filename: "{cmd}"; \
+    WorkingDir: "{commoncf64}\VST3"; \
+    Parameters: "/C mklink /D ""{commoncf64}\VST3\{#PluginName}Data"" ""{commonappdata}\{#PluginName}"""; \
+    Flags: runascurrentuser;


### PR DESCRIPTION
These changes resolve https://github.com/sudara/pamplejuce/issues/16 and 
its duplicate https://github.com/sudara/pamplejuce/issues/25.

A link to a data directory is added alongside the plugin. The uninstaller is in this data
directory. But other things can be added.

I also got rid of some flags as I didn't know whether they were necessary
and moved the check for 64 bit architecture to `[Setup]`. This should cause
installation to explicitly fail if there is an architecture mismatch.
