### PR TITLE
Fix minimum OSX deployment target by moving it above project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(PROJECT_NAME "Pamplejuce")
 # Valid formats: AAX Unity VST AU AUv3 Standalone
 set(FORMATS AU VST3 AUv3)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Support macOS down to High Sierra")
+
 # Reads in VERSION file and sticks in it CURRENT_VERSION variable
 # Be sure the file has no newlines
 file(STRINGS VERSION CURRENT_VERSION)
@@ -26,8 +28,6 @@ if ((DEFINED ENV{CI}) AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
   message("Building for Apple Silicon and x86_64")
   set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
 endif ()
-
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Support macOS down to High Sierra")
 
 # Adds all the module sources so they appear correctly in the IDE
 # Must be set before JUCE is added as a sub-dir (or any targets are made)


### PR DESCRIPTION
Hi, I discovered this issue when testing a project on an older machine. Turns out the command set(CMAKE_OSX_DEPLOYMENT_TARGET ...) has to be called before project() in order for it to work. 

See before and after screenshots of generated Xcode project below:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/55414450/231506111-ebac33c7-c327-4826-ad29-b95def8d6128.png">
<img width="409" alt="image" src="https://user-images.githubusercontent.com/55414450/231506789-c5747caf-9a25-4b52-aa71-4884e53cac2a.png">
