### PR TITLE
Feat: Package standalone application

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -129,9 +129,10 @@ jobs:
       shell: bash
       run: |
         echo "ARTIFACTS_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
-        echo "VST3_PATH=${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PRODUCT_NAME }}.vst3" >> $GITHUB_ENV
-        echo "AU_PATH=${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/AU/${{ env.PRODUCT_NAME }}.component" >> $GITHUB_ENV
-        echo "AUV3_PATH=${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/AUv3/${{ env.PRODUCT_NAME }}.appex" >> $GITHUB_ENV          
+        echo "VST3_PATH=${{ env.ARTIFACTS_PATH }}/VST3/${{ env.PRODUCT_NAME }}.vst3" >> $GITHUB_ENV
+        echo "AU_PATH=${{ env.ARTIFACTS_PATH }}/AU/${{ env.PRODUCT_NAME }}.component" >> $GITHUB_ENV
+        echo "AUV3_PATH=${{ env.ARTIFACTS_PATH }}/AUv3/${{ env.PRODUCT_NAME }}.appex" >> $GITHUB_ENV          
+        echo "STANDALONE_PATH=${{ env.ARTIFACTS_PATH }}/Standalone/${{ env.PRODUCT_NAME }}.app" >> $GITHUB_ENV
         echo "ARTIFACT_NAME=${{ env.PRODUCT_NAME }}-${{ env.VERSION }}-${{ matrix.name }}" >> $GITHUB_ENV
 
     - name: Pluginval
@@ -149,6 +150,7 @@ jobs:
         # Each plugin must be code signed
         codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.VST3_PATH }}" --deep --strict --options=runtime --timestamp
         codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.AU_PATH }}" --deep --strict --options=runtime --timestamp
+        codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.STANDALONE_PATH }}" --deep --strict --options=runtime --timestamp
 
     - name: Add Custom Icons (macOS)
       if: ${{ matrix.name == 'macOS' }}
@@ -178,8 +180,9 @@ jobs:
         sudo mkdir -m 755 -p /Library/Audio/Plug-Ins/Components && sudo mkdir -m 755 -p /Library/Audio/Plug-Ins/VST3
         ln -s /Library/Audio/Plug-Ins/Components "packaging/dmg/Your Mac's Component folder"
         ln -s /Library/Audio/Plug-Ins/VST3 "packaging/dmg/Your Mac's VST3 folder"
-        mv "${{ env.ARTIFACTS_PATH }}/VST3/${{ env.PRODUCT_NAME }}.vst3" packaging/dmg
-        mv "${{ env.ARTIFACTS_PATH }}/AU/${{ env.PRODUCT_NAME }}.component" packaging/dmg
+        mv "${{ env.VST3_PATH }}" packaging/dmg
+        mv "${{ env.AU_PATH }}" packaging/dmg
+        mv "${{ env.STANDALONE_PATH }}" packaging/dmg
         
         # Run appdmg to create the .dmg
         cd packaging && appdmg dmg.json "${{ env.ARTIFACT_NAME}}.dmg"

--- a/packaging/dmg.json
+++ b/packaging/dmg.json
@@ -14,9 +14,11 @@
   },
   "format": "UDZO",
   "contents": [
-    { "x": 250, "y": 245, "type": "file", "path": "dmg/Pamplejuce Demo.component" },
-    { "x": 480, "y": 245, "type": "file", "path": "dmg/Your Mac's Component Folder" },
-    { "x": 250, "y": 405, "type": "file", "path": "dmg/Pamplejuce Demo.vst3" },
-    { "x": 480, "y": 405, "type": "file", "path": "dmg/Your Mac's VST3 Folder" }
+    { "x": 250, "y": 200, "type": "file", "path": "dmg/Pamplejuce Demo.app" },
+    { "x": 480, "y": 200, "type": "link", "path": "/Applications" },
+    { "x": 250, "y": 300, "type": "file", "path": "dmg/Pamplejuce Demo.component" },
+    { "x": 480, "y": 300, "type": "file", "path": "dmg/Your Mac's Component Folder" },
+    { "x": 250, "y": 400, "type": "file", "path": "dmg/Pamplejuce Demo.vst3" },
+    { "x": 480, "y": 400, "type": "file", "path": "dmg/Your Mac's VST3 Folder" }
   ]
 }

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -26,7 +26,7 @@ DefaultDirName="{commoncf64}\VST3\{#ProductName}.vst3"
 DisableDirPage=yes
 
 ; MAKE SURE YOU READ THE FOLLOWING!
-LicenseFile="..\LICENSE"
+LicenseFile="EULA"
 UninstallFilesDir="{commonappdata}\{#ProductName}\uninstall"
 
 [UninstallDelete]

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -4,6 +4,16 @@
 #define Publisher GetEnv('COMPANY_NAME')
 #define Year GetDateTimeString("yyyy","","")
 
+; 'Types': What get displayed during the setup
+[Types]
+Name: "full"; Description: "Full installation"
+Name: "custom"; Description: "Custom installation"; Flags: iscustom
+
+; Components are used inside the script and can be composed of a set of 'Types'
+[Components]
+Name: "standalone"; Description: "Standalone application"; Types: full custom
+Name: "vst3"; Description: "VST3 plugin"; Types: full custom
+
 [Setup]
 ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
@@ -16,7 +26,7 @@ DefaultDirName="{commoncf64}\VST3\{#ProductName}.vst3"
 DisableDirPage=yes
 
 ; MAKE SURE YOU READ THE FOLLOWING!
-LicenseFile="EULA"
+LicenseFile="..\LICENSE"
 UninstallFilesDir="{commonappdata}\{#ProductName}\uninstall"
 
 [UninstallDelete]
@@ -24,10 +34,15 @@ Type: filesandordirs; Name: "{commoncf64}\VST3\{#ProductName}Data"
 
 ; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
-Source: "..\Builds\{#ProjectName}_artefacts\Release\VST3\{#ProductName}.vst3\*"; DestDir: "{commoncf64}\VST3\{#ProductName}.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs;
+Source: "..\Builds\{#ProjectName}_artefacts\Release\VST3\{#ProductName}.vst3\*"; DestDir: "{commoncf64}\VST3\{#ProductName}.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs; Components: vst3
+Source: "..\Builds\{#ProjectName}_artefacts\Release\Standalone\{#ProductName}.exe"; DestDir: "{commonpf64}\{#Publisher}\{#ProductName}"; Flags: ignoreversion; Components: standalone
+
+[Icons]
+Name: "{autoprograms}\{#ProductName}"; Filename: "{commonpf64}\{#Publisher}\{#ProductName}\{#ProductName}.exe"; Components: standalone 
+Name: "{autoprograms}\Uninstall {#ProductName}"; Filename: "{uninstallexe}"
 
 [Run]
 Filename: "{cmd}"; \
     WorkingDir: "{commoncf64}\VST3"; \
     Parameters: "/C mklink /D ""{commoncf64}\VST3\{#ProductName}Data"" ""{commonappdata}\{#ProductName}"""; \
-    Flags: runascurrentuser;
+    Flags: runascurrentuser; Components: vst3


### PR DESCRIPTION
Happy Hacktoberfest!

After modifying the template for my own uses, I noticed that the Standalone version of the plugin is built, but not packaged in the Windows installer or macOS DMG. This PR fixes that in a few places so that developers can distribute all versions of their plugin together.

- Signs, notarizes and adds standalone application to macOS dmg
- Adds options for custom windows installation, otherwise installs both the VST and standalone
    - Adds ICONS section for exe and uninstall shortcuts

Some notes before considering merging:
- These changes have been used in my [gRainbow](https://github.com/StrangeLoopsAudio/gRainbow) plugin, but have been pasted in here without testing the full template, since other modifications were made to that repo that wouldn't let me update the template directly
- How to handle if the user disables the standalone build? Might be up to them to comment out the standalone lines or could be cleaned up a bit.