### PR TITLE
Fix macOS build

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -175,7 +175,7 @@ jobs:
       if: ${{ matrix.name == 'macOS' }}
       run: |
         # workaround for https://github.com/LinusU/node-appdmg/issues/234
-        python3 -m pip install setuptools
+        python3 -m pip install setuptools --break-system-packages
         npm install -g appdmg
         mkdir -p packaging/dmg
         


### PR DESCRIPTION
Fixes #85

python doesn't like system packages being installed anymore.

This will all be moot when #46 is done.