### PR TITLE
Enable SCCACHE_CACHE_MULTIARCH env variable for macOS caching

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,7 @@ env:
   DISPLAY: :0 # linux pluginval needs this
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   SCCACHE_GHA_ENABLED: true
+  SCCACHE_CACHE_MULTIARCH: 1
   IPP_DIR: C:\Program Files (x86)\Intel\oneAPI\ipp\latest\lib\cmake\ipp
 
 defaults:


### PR DESCRIPTION
__Problem__
On macOS builds, sccache was previously not caching anything from the CMake build:

```
Compile requests                    132
Compile requests executed             0
Cache hits                            0
Cache misses                          0
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                  0
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                 132
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.000 s
Average compiler                  0.000 s
Average cache read hit            0.000 s
Failed distributed compilations       0

Non-cacheable reasons:
multiple different -arch, and SCCACHE_CACHE_MULTIARCH not set     132

Cache location                  ghac, name: sccache-v0.8.1, prefix: /sccache/
Version (client)                0.8.1
```

From checking the source code of sccache, we can see this is due to sccache defaulting to not caching builds when it detects multiple target architectures, which is the case for our macOS builds ([source](https://github.com/mozilla/sccache/blob/main/src/compiler/gcc.rs#L286))

__Solution__
Set the SCCACHE_CACHE_MULTIARCH variable. On my first build setting this, we no longer see any non-cacheable calls:


```
Compile requests                    132
Compile requests executed           132
Cache hits                            0
Cache misses                        132
Cache misses (C/C++)                132
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                  0
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                   0
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.188 s
Average compiler                  3.094 s
Average cache read hit            0.000 s
Failed distributed compilations       0
Cache location                  ghac, name: sccache-v0.8.1, prefix: /sccache/
Version (client)                0.8.1
```