### PR TITLE
Allow InnoSetup installer to run on arm64 architectures

### DIFF
--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -15,8 +15,8 @@ Name: "standalone"; Description: "Standalone application"; Types: full custom
 Name: "vst3"; Description: "VST3 plugin"; Types: full custom
 
 [Setup]
-ArchitecturesInstallIn64BitMode=x64
-ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible
 AppName={#ProductName}
 OutputBaseFilename={#ProductName}-{#Version}-Windows
 AppCopyright=Copyright (C) {#Year} {#Publisher}


### PR DESCRIPTION
Currently, on my Windows running on Parallels via an Apple Silicon Mac, the installer generated by Innosetup gives this error:

![Screenshot 2024-09-27 at 12 12 40 AM](https://github.com/user-attachments/assets/ab2ba377-5527-41f3-99c1-40cd71de319f)

Setting this value to `x64compatible` resolves this error.

Docs:
- https://jrsoftware.org/ishelp/topic_setup_architecturesallowed.htm
- https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode 