### PR TITLE
fix: properly check for min os version in macos pkg xml

### DIFF
--- a/packaging/distribution.xml.template
+++ b/packaging/distribution.xml.template
@@ -1,7 +1,9 @@
 <?xml version='1.0' encoding='utf8'?>
 <installer-gui-script minSpecVersion="2">
     <title>${PRODUCT_NAME}</title>
-    <os-version min="10.13" />
+    <allowed-os-versions>
+        <os-version min="10.13" />
+    </allowed-os-versions>
     <license file="EULA" />
     <readme file="README" />
     <background file="background.png" mime-type="image/png" scaling="tofit" alignment="bottomleft"/>


### PR DESCRIPTION
Just `<os-version min="10.13" />` in the macOS distribution xml will not actually prevent the user from installing the software on an incompatible os version, this needs to be wrapped in `<allowed-os-versions>`