### PR TITLE
Add timeout to codesigning, also move it just before its needed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,16 +109,6 @@ jobs:
       - name: Cache the build
         uses: mozilla-actions/sccache-action@v0.0.7
 
-      - name: Import Certificates (macOS)
-        uses: sudara/basic-macos-keychain-action@v1
-        id: keychain
-        if: ${{ matrix.name == 'macOS'}}
-        with:
-          dev-id-app-cert: ${{ secrets.DEV_ID_APP_CERT }}
-          dev-id-app-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
-          dev-id-installer-cert: ${{ secrets.DEV_ID_INSTALLER_CERT }}
-          dev-id-installer-password: ${{ secrets.DEV_ID_INSTALLER_PASSWORD }}
-
       - name: Configure
         run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ matrix.extra-flags }} .
 
@@ -150,6 +140,17 @@ jobs:
           curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${{ matrix.name }}.zip"
           7z x pluginval_${{ matrix.name }}.zip
           ${{ matrix.pluginval-binary }} --strictness-level 10 --verbose --validate "${{ env.VST3_PATH }}"
+
+      - name: Import Certificates (macOS)
+        uses: sudara/basic-macos-keychain-action@v1
+        id: keychain
+        if: ${{ matrix.name == 'macOS'}}
+        timeout-minutes: 5
+        with:
+          dev-id-app-cert: ${{ secrets.DEV_ID_APP_CERT }}
+          dev-id-app-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
+          dev-id-installer-cert: ${{ secrets.DEV_ID_INSTALLER_CERT }}
+          dev-id-installer-password: ${{ secrets.DEV_ID_INSTALLER_PASSWORD }}          
 
       - name: Codesign (macOS)
         if: ${{ matrix.name == 'macOS' }}


### PR DESCRIPTION
The keychain created in Import Certificates seems to lock after a period of time, so moving the installation of the certificates after the code build just before they are needed.  The 5 minute timeout was added due to a situation I was facing where a prompt to enter the keychain passwork had popped up and the step kept running until the whole workflow timed out.