### PR TITLE
Update SCCACHE to v0.0.9

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,7 +107,7 @@ jobs:
           submodules: recursive
 
       - name: Cache the build
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Import Certificates (macOS)
         uses: sudara/basic-macos-keychain-action@v1


### PR DESCRIPTION
The configuration of sccache included in pamplejuce has now been deprecated since April 15th, 2025 and all builds are failing.

This is an updated configuration to work with the latest version.