### PR TITLE
Improve CI speed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,12 +47,13 @@ jobs:
           - name: Windows
             os: windows-latest
             pluginval-binary: ./pluginval.exe
+            extra-flags: -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
     steps:
       # Setup MSVC toolchain and developer command prompt (Windows)
       - uses: ilammy/msvc-dev-cmd@v1
 
-      # Use clang on Linux so we don't introduce a 3rd compiler (Windows and macOS use MSVC and Clang)
+      # Use clang on Linux (all three platforms now use Clang)
       - name: Set up Clang
         if: runner.os == 'Linux'
         uses: egor-tensin/setup-clang@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
           - name: Linux
             os: ubuntu-22.04
             pluginval-binary: ./pluginval
-            extra-flags: -G Ninja
+            extra-flags: -G Ninja -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld
           - name: macOS
             os: macos-14
             pluginval-binary: pluginval.app/Contents/MacOS/pluginval

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,6 +18,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   SCCACHE_GHA_ENABLED: true
   SCCACHE_CACHE_MULTIARCH: 1
+  CPM_SOURCE_CACHE: .cpm-cache
   IPP_DIR: C:\Program Files (x86)\Intel\oneAPI\ipp\latest\lib\cmake\ipp
 
 defaults:
@@ -89,6 +90,13 @@ jobs:
 
       - name: Cache the build
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache CPM downloads
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}
+          restore-keys: cpm-${{ runner.os }}-
 
       - name: Configure
         run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ matrix.extra-flags }} .

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,6 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   SCCACHE_GHA_ENABLED: true
   SCCACHE_CACHE_MULTIARCH: 1
-  CPM_SOURCE_CACHE: .cpm-cache
   IPP_DIR: C:\Program Files (x86)\Intel\oneAPI\ipp\latest\lib\cmake\ipp
 
 defaults:
@@ -90,13 +89,6 @@ jobs:
 
       - name: Cache the build
         uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Cache CPM downloads
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.CPM_SOURCE_CACHE }}
-          key: cpm-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}
-          restore-keys: cpm-${{ runner.os }}-
 
       - name: Configure
         run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ matrix.extra-flags }} .


### PR DESCRIPTION
Speed up linux with lld — this helps as projects grow.

Also move Windows back to clang-cl, perf is improved:
```
  ┌───────────┬────────┬─────────────┬─────────────────┬─────────────────┐
  │           │  MSVC  │ MSVC (warm) │ Clang-cl (cold) │ Clang-cl (warm) │
  ├───────────┼────────┼─────────────┼─────────────────┼─────────────────┤
  │ Configure │ 1m55s  │ 1m48s       │ 2m03s           │ 0m38s           │
  ├───────────┼────────┼─────────────┼─────────────────┼─────────────────┤
  │ Build     │ 12m00s │ 11m34s      │ 7m11s           │ 2m32s           │
  ├───────────┼────────┼─────────────┼─────────────────┼─────────────────┤
  │ Tests     │ 5s     │ 5s          │ 6s              │ 7s              │
  ├───────────┼────────┼─────────────┼─────────────────┼─────────────────┤
  │ Pluginval │ 15s    │ 15s         │ —               │ 16s             │
  ├───────────┼────────┼─────────────┼─────────────────┼─────────────────┤
  │ Total job │ ~15m   │ ~15m        │ ~11m*           │ ~5m             │
  └───────────┴────────┴─────────────┴─────────────────┴─────────────────┘
```